### PR TITLE
Trigger information display and comparator

### DIFF
--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCTool.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCTool.hh
@@ -11,7 +11,7 @@ namespace duneana {
 
   public:
 
-    static const unsigned int ADC_SAMPLING_RATE_IN_DTS = 32; //32 DTS time ticks betwen adc samples
+    static const unsigned int ADC_SAMPLING_RATE_IN_DTS = 32; //32 DTS time ticks between adc samples
 
     virtual ~TPAlgTPCTool() noexcept = default; 
 

--- a/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
@@ -1,0 +1,300 @@
+/**
+ * @file TriggerTPCInfoComparator_module.cc
+ *
+ * @brief This module compares offline and online trigger information for TPC.
+ *
+ * The TriggerTPCInfoComparator module compares the trigger information obtained from LArSoft (offline trigger) and the DAQ (online trigger) for the TPC. It analyzes the TPs (Trigger Primitives), TAs (Trigger Activities), and TCs (Trigger Candidates) and compares them to check for any discrepancies or differences between the offline and online triggers.
+ *
+ * The module takes the following input tags:
+ * - tp_tag: Input tag for the TriggerPrimitive data from LArSoft
+ * - ta_tag: Input tag for the TriggerActivity data from LArSoft
+ * - tc_tag: Input tag for the TriggerCandidate data from LArSoft
+ * - daq_tag: Input tag for the trigger data from the DAQ
+ *
+ * The module performs the following tasks:
+ * - Compares the offline and online TPs and sets the comparison result
+ * - Compares the offline and online TAs and sets the comparison result
+ * - Compares the offline and online TCs and sets the comparison result
+ *
+ * The module also provides general event information such as run number, subrun number, and event ID.
+ *
+ * This module is generated using cetskelgen.
+ *
+ * @date Mon May 13 2024
+ * @author Hamza Amar Es-sghir
+ */
+////////////////////////////////////////////////////////////////////////
+// Class:       TriggerTPCInfoComparator
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        TriggerTPCInfoComparator_module.cc
+//
+// Generated at Mon Apr 29 11:24:28 2024 by Hamza Amar Es-sghir using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "detdataformats/trigger/TriggerCandidateData.hpp"
+#include "detdataformats/trigger/TriggerActivityData.hpp"
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "detdataformats/DetID.hpp"
+#include "lardataobj/RawData/RawDigit.h"
+#include "lardataobj/RawData/RDTimeStamp.h"
+
+#include "larcore/Geometry/Geometry.h"
+
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Utilities/make_tool.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// Additional framework includes
+#include "art_root_io/TFileDirectory.h"
+#include "art_root_io/TFileService.h"
+
+// ROOT includes
+#include <TH1I.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TTree.h>
+#include <TFile.h>
+#include <TGraph.h>
+#include <TRandom.h>
+#include <TVector3.h>
+#include <fcntl.h>
+
+#include <memory>
+#include <algorithm>
+#include <iostream>
+
+namespace duneana {
+  class TriggerTPCInfoComparator;
+}
+
+
+class duneana::TriggerTPCInfoComparator : public art::EDAnalyzer {
+public:
+  explicit TriggerTPCInfoComparator(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  TriggerTPCInfoComparator(TriggerTPCInfoComparator const&) = delete;
+  TriggerTPCInfoComparator(TriggerTPCInfoComparator&&) = delete;
+  TriggerTPCInfoComparator& operator=(TriggerTPCInfoComparator const&) = delete;
+  TriggerTPCInfoComparator& operator=(TriggerTPCInfoComparator&&) = delete;
+
+  // Required functions.
+  void analyze(art::Event const& e) override;
+
+  // Selected optional functions.
+  void beginJob() override;
+
+private:
+
+  // General event information
+  int fRun;
+  int fSubRun;
+  unsigned int fEventID;
+
+  // Comparison TTrees
+  TTree *fTPComparisonTree;
+  TTree *fTAComparisonTree;
+  TTree *fTCComparisonTree;
+  
+  // Variables for comparison
+  long unsigned int fTPSizeOffline, fTPSizeOnline;
+  long unsigned int fTASizeOffline, fTASizeOnline;
+  long unsigned int fTCSizeOffline, fTCSizeOnline;
+  std::vector<bool> fTPComparison, fTAComparison, fTCComparison;
+
+  art::InputTag tp_tag_, ta_tag_, tc_tag_;
+  art::InputTag daq_tag;
+  int verbosity_;
+
+  // Trigger information from LArSoft (offline trigger) and DAQ (online trigger)
+  std::vector<dunedaq::trgdataformats::TriggerPrimitive> fTriggerPrimitive, fTriggerPrimitiveDAQ;
+  std::vector<dunedaq::trgdataformats::TriggerActivityData> fTriggerActivity, fTriggerActivityDAQ;
+  std::vector<dunedaq::trgdataformats::TriggerCandidateData> fTriggerCandidate, fTriggerCandidateDAQ;
+};
+
+
+duneana::TriggerTPCInfoComparator::TriggerTPCInfoComparator(fhicl::ParameterSet const& p)
+  : EDAnalyzer{p}  // ,
+  , tp_tag_(p.get<art::InputTag>("tp_tag"))
+  , ta_tag_(p.get<art::InputTag>("ta_tag"))
+  , tc_tag_(p.get<art::InputTag>("tc_tag"))
+  , daq_tag(p.get<art::InputTag>("daq_tag"))
+  , verbosity_(p.get<int>("verbosity",0))
+{
+  // Consumes offline trigger information
+  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive>>(tp_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData>>(ta_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData>>(tc_tag_);
+
+  // Consumes DAQ trigger information
+  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive>>(daq_tag);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData>>(daq_tag);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData>>(daq_tag);
+}
+
+void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
+{
+  // Set all general event information
+  fRun    = e.run();
+  fSubRun = e.subRun();
+  fEventID = e.id().event();
+
+  // Take TPs from event
+  auto tp_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(tp_tag_);  
+  fTriggerPrimitive = *tp_handle;
+
+  // Take TAs from event
+  auto ta_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);
+  fTriggerActivity = *ta_handle;
+
+  // Take TCs from event
+  auto tc_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerCandidateData> >(tc_tag_);
+  fTriggerCandidate = *tc_handle;
+
+  // Take DAQ TPs from event
+  auto daq_tp_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(daq_tag);
+  fTriggerPrimitiveDAQ = *daq_tp_handle;
+
+  // Take DAQ TAs from event
+  auto daq_ta_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerActivityData> >(daq_tag);
+  fTriggerActivityDAQ = *daq_ta_handle;
+
+  // Take DAQ TCs from event
+  auto daq_tc_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerCandidateData> >(daq_tag);
+  fTriggerCandidateDAQ = *daq_tc_handle;
+
+  // Load the geometry service
+  art::ServiceHandle<geo::Geometry> geom;
+
+  if(verbosity_>0)
+  {
+    std::cout << "Offline summary" << std::endl; 
+    std::cout << "Found " << fTriggerPrimitive.size() << " TPs" << std::endl;
+    std::cout << "Found " << fTriggerActivity.size() << " TAs" << std::endl;
+    std::cout << "Found " << fTriggerCandidate.size() << " TCs" << std::endl << std::endl;
+
+    std::cout << "DAQ summary" << std::endl;
+    std::cout << "Found " << fTriggerPrimitiveDAQ.size() << " TPs" << std::endl;
+    std::cout << "Found " << fTriggerActivityDAQ.size() << " TAs" << std::endl;
+    std::cout << "Found " << fTriggerCandidateDAQ.size() << " TCs" << std::endl;
+  }
+
+  // Compare offline and online TPs
+  fTPSizeOffline = fTriggerPrimitive.size();
+  fTPSizeOnline = fTriggerPrimitiveDAQ.size();
+  long unsigned int minTPSize = std::min(fTPSizeOffline, fTPSizeOnline);
+  fTPComparison.resize(minTPSize);
+  for (long unsigned int i = 0; i < minTPSize; i++) {
+    bool foundMatch = false; //  to check if a match is found
+    for (long unsigned int j = 0; j < fTriggerPrimitiveDAQ.size(); j++) {
+      // Compare TPs and set comparison result
+      if (fTriggerPrimitive[i].channel == fTriggerPrimitiveDAQ[j].channel &&
+        fTriggerPrimitive[i].time_start == fTriggerPrimitiveDAQ[j].time_start &&
+        fTriggerPrimitive[i].time_over_threshold == fTriggerPrimitiveDAQ[j].time_over_threshold &&
+        fTriggerPrimitive[i].time_peak == fTriggerPrimitiveDAQ[j].time_peak &&
+        fTriggerPrimitive[i].adc_integral == fTriggerPrimitiveDAQ[j].adc_integral &&
+        fTriggerPrimitive[i].adc_peak == fTriggerPrimitiveDAQ[j].adc_peak &&
+        fTriggerPrimitive[i].detid == fTriggerPrimitiveDAQ[j].detid &&
+        fTriggerPrimitive[i].type == fTriggerPrimitiveDAQ[j].type &&
+        fTriggerPrimitive[i].algorithm == fTriggerPrimitiveDAQ[j].algorithm) {
+      foundMatch = true;
+      break; // Break the loop if a match is found
+      }
+    }
+
+    fTPComparison[i] = foundMatch; // Set comparison result
+  } 
+
+  // Compare offline and online TAs
+  fTASizeOffline = fTriggerActivity.size();
+  fTASizeOnline = fTriggerActivityDAQ.size();
+  long unsigned int minTASize = std::min(fTASizeOffline, fTASizeOnline);
+  fTAComparison.resize(minTASize);
+  for (long unsigned int i = 0; i < minTASize; i++) {
+    bool foundMatch = false; // to check if a match is found
+    for(long unsigned int j = 0; j < fTriggerActivityDAQ.size(); j++) {
+      // Compare TAs and set comparison result
+      if (fTriggerActivity[i].channel_start == fTriggerActivityDAQ[j].channel_start &&
+          fTriggerActivity[i].channel_end == fTriggerActivityDAQ[j].channel_end &&
+          fTriggerActivity[i].channel_peak == fTriggerActivityDAQ[j].channel_peak &&
+          fTriggerActivity[i].time_start == fTriggerActivityDAQ[j].time_start &&
+          fTriggerActivity[i].time_end == fTriggerActivityDAQ[j].time_end &&
+          fTriggerActivity[i].time_peak == fTriggerActivityDAQ[j].time_peak &&
+          fTriggerActivity[i].time_activity == fTriggerActivityDAQ[j].time_activity &&
+          fTriggerActivity[i].adc_integral == fTriggerActivityDAQ[j].adc_integral &&
+          fTriggerActivity[i].adc_peak == fTriggerActivityDAQ[j].adc_peak &&
+          fTriggerActivity[i].detid == fTriggerActivityDAQ[j].detid &&
+          fTriggerActivity[i].type == fTriggerActivityDAQ[j].type &&
+          fTriggerActivity[i].algorithm == fTriggerActivityDAQ[j].algorithm) {
+        foundMatch = true;
+        break; // Break the loop if a match is found
+      }
+    }
+    fTAComparison[i] = foundMatch; // Set comparison result
+  }
+
+  // Compare offline and online TCs 
+  fTCSizeOffline = fTriggerCandidate.size();
+  fTCSizeOnline = fTriggerCandidateDAQ.size();
+  long unsigned int minTCSize = std::min(fTCSizeOffline, fTCSizeOnline);
+  fTCComparison.resize(minTCSize);
+  for (long unsigned int i = 0; i < minTCSize; i++) {
+    bool foundMatch = false; // to check if a match is found
+    for (long unsigned int j = 0; j < fTriggerCandidateDAQ.size(); j++) {
+      // Compare TCs and set comparison result
+      if (fTriggerCandidate[i].time_start == fTriggerCandidateDAQ[j].time_start &&
+          fTriggerCandidate[i].time_end == fTriggerCandidateDAQ[j].time_end &&
+          fTriggerCandidate[i].time_candidate == fTriggerCandidateDAQ[j].time_candidate &&
+          fTriggerCandidate[i].version == fTriggerCandidateDAQ[j].version &&
+          fTriggerCandidate[i].detid == fTriggerCandidateDAQ[j].detid &&
+          fTriggerCandidate[i].type == fTriggerCandidateDAQ[j].type &&
+          fTriggerCandidate[i].algorithm == fTriggerCandidateDAQ[j].algorithm) {
+        foundMatch = true;
+        break; // Break the loop if a match is found
+      }
+    }
+    fTCComparison[i] = foundMatch; // Set comparison result
+  }
+
+  // Fill the comparison TTrees
+  fTPComparisonTree->Fill();
+  fTAComparisonTree->Fill();
+  fTCComparisonTree->Fill();
+}
+
+void duneana::TriggerTPCInfoComparator::beginJob()
+{
+  // Make our handle to the TFileService
+  art::ServiceHandle<art::TFileService> tfs;
+
+  // Create offline vs online comparison TTrees
+  fTPComparisonTree = tfs->make<TTree>("TPComparisonTree", "Offline vs Online TP Comparison");
+  fTAComparisonTree = tfs->make<TTree>("TAComparisonTree", "Offline vs Online TA Comparison");
+  fTCComparisonTree = tfs->make<TTree>("TCComparisonTree", "Offline vs Online TC Comparison");
+
+  // Set branch addresses for comparison TTrees
+  fTPComparisonTree->Branch("SizeOffline", &fTPSizeOffline, "SizeOffline/I");
+  fTPComparisonTree->Branch("SizeOnline", &fTPSizeOnline, "SizeOnline/I");
+  fTPComparisonTree->Branch("Comparison", &fTPComparison);
+
+  fTAComparisonTree->Branch("SizeOffline", &fTASizeOffline, "SizeOffline/I");
+  fTAComparisonTree->Branch("SizeOnline", &fTASizeOnline, "SizeOnline/I");
+  fTAComparisonTree->Branch("Comparison", &fTAComparison);
+
+  fTCComparisonTree->Branch("SizeOffline", &fTCSizeOffline, "SizeOffline/I");
+  fTCComparisonTree->Branch("SizeOnline", &fTCSizeOnline, "SizeOnline/I");
+  fTCComparisonTree->Branch("Comparison", &fTCComparison);
+
+}
+
+DEFINE_ART_MODULE(duneana::TriggerTPCInfoComparator)

--- a/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
@@ -1,0 +1,302 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       TriggerTPCInfoDisplay
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        TriggerTPCInfoDisplay_module.cc
+//
+// Generated at Mon Apr 29 11:24:28 2024 by Hamza Amar Es-sghir using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "detdataformats/trigger/TriggerCandidateData.hpp"
+#include "detdataformats/trigger/TriggerActivityData.hpp"
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "detdataformats/DetID.hpp"
+#include "lardataobj/RawData/RawDigit.h"
+#include "lardataobj/RawData/RDTimeStamp.h"
+
+#include "larcore/Geometry/Geometry.h"
+
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Utilities/make_tool.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// Additional framework includes
+#include "art_root_io/TFileDirectory.h"
+#include "art_root_io/TFileService.h"
+
+// ROOT includes
+#include <TH1I.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TTree.h>
+#include <TFile.h>
+#include <TGraph.h>
+#include <TRandom.h>
+#include <TVector3.h>
+#include <fcntl.h>
+
+#include <memory>
+#include <algorithm>
+#include <iostream>
+
+namespace duneana {
+  class TriggerTPCInfoDisplay;
+}
+
+
+class duneana::TriggerTPCInfoDisplay : public art::EDAnalyzer {
+public:
+  explicit TriggerTPCInfoDisplay(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  TriggerTPCInfoDisplay(TriggerTPCInfoDisplay const&) = delete;
+  TriggerTPCInfoDisplay(TriggerTPCInfoDisplay&&) = delete;
+  TriggerTPCInfoDisplay& operator=(TriggerTPCInfoDisplay const&) = delete;
+  TriggerTPCInfoDisplay& operator=(TriggerTPCInfoDisplay&&) = delete;
+
+  // Required functions.
+  void analyze(art::Event const& e) override;
+
+  // Selected optional functions.
+  void beginJob() override;
+
+private:
+
+  // Create output Tree
+  TTree *fTPTree;
+  TTree *fTATree;
+  TTree *fTCTree;
+
+  // General event information
+  int fRun;
+  int fSubRun;
+  unsigned int fEventID;
+
+  ////////////////////////
+  // fTPTree variables //
+  ///////////////////////
+  using timestamp_t = int64_t;
+  using channel_t = uint32_t;
+  using version_t = uint16_t;
+  using detid_t = uint16_t;
+
+  channel_t fChannelID;
+  timestamp_t fStart_time;
+  timestamp_t fTime_over_threshold;
+  timestamp_t fTime_peak;
+  uint32_t fADC_integral;
+  uint16_t fADC_peak;
+  int fROI_ID;
+  detid_t fDetID;
+  int fType;
+  int fAlgorithm;
+
+  ////////////////////////
+  // fTATree variables //
+  ///////////////////////
+  channel_t fChannel_start_TA;
+  channel_t fChannel_end_TA;
+  channel_t fChannel_peak_TA;
+  timestamp_t fTime_start_TA;
+  timestamp_t fTime_end_TA;
+  timestamp_t fTime_peak_TA;
+  timestamp_t fTime_activity;
+  uint32_t fADC_integral_TA;
+  uint16_t fADC_peak_TA;
+  int fAlgorithm_TA;
+
+  ////////////////////////
+  // fTCTree variables //
+  ///////////////////////
+  timestamp_t fTime_start_TC;
+  timestamp_t fTime_end_TC;
+  timestamp_t fTime_candidate;
+  version_t version;
+  unsigned int fType_TC;
+  unsigned int fAlgorithm_TC;
+
+  art::InputTag tp_tag_;
+  art::InputTag ta_tag_;
+  art::InputTag tc_tag_;
+  int verbosity_;
+
+  // Trigger information
+  std::vector<dunedaq::trgdataformats::TriggerActivityData> fTriggerActivity;
+  std::vector<dunedaq::trgdataformats::TriggerPrimitive> fTriggerPrimitive;
+  std::vector<dunedaq::trgdataformats::TriggerCandidateData> fTriggerCandidate;
+  
+};
+
+
+duneana::TriggerTPCInfoDisplay::TriggerTPCInfoDisplay(fhicl::ParameterSet const& p)
+  : EDAnalyzer{p}  // ,
+  , tp_tag_(p.get<art::InputTag>("tp_tag"))
+  , ta_tag_(p.get<art::InputTag>("ta_tag"))
+  , tc_tag_(p.get<art::InputTag>("tc_tag"))
+  , verbosity_(p.get<int>("verbosity",0))
+{
+  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive>>(tp_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData>>(ta_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData>>(tc_tag_);
+}
+
+void duneana::TriggerTPCInfoDisplay::analyze(art::Event const& e)
+{
+  // Set all general event information
+  fRun    = e.run();
+  fSubRun = e.subRun();
+  fEventID = e.id().event();
+
+  // Take TPs from event
+  auto tp_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(tp_tag_);  
+  fTriggerPrimitive = *tp_handle;
+
+  // Take TAs from event
+  auto ta_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);
+  fTriggerActivity = *ta_handle;
+
+  // Take TCs from event
+  auto tc_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerCandidateData> >(tc_tag_);
+  fTriggerCandidate = *tc_handle;
+
+  // Load the geometry service
+  art::ServiceHandle<geo::Geometry> geom;
+
+  if(verbosity_>0)
+  {
+    //std::cout << "Found " << rawdigit_vec.size() << " raw::RawDigits" << std::endl;
+    std::cout << "Found " << fTriggerPrimitive.size() << " TPs" << std::endl;
+    std::cout << "Found " << fTriggerActivity.size() << " TAs" << std::endl;
+    std::cout << "Found " << fTriggerCandidate.size() << " TCs" << std::endl;
+  }
+
+  // Fill TP tree
+  for(long unsigned int i=0; i < fTriggerPrimitive.size(); i++)
+  {
+    fChannelID = fTriggerPrimitive[i].channel;
+    fStart_time = fTriggerPrimitive[i].time_start;
+    fTime_over_threshold = fTriggerPrimitive[i].time_over_threshold;
+    fTime_peak = fTriggerPrimitive[i].time_peak;
+    fADC_integral = fTriggerPrimitive[i].adc_integral;
+    fADC_peak = fTriggerPrimitive[i].adc_peak;
+    fDetID = fTriggerPrimitive[i].detid;
+    fType = static_cast<int>(fTriggerPrimitive[i].type);
+    fAlgorithm = static_cast<int>(fTriggerPrimitive[i].algorithm);
+    
+    // Get ROP ID (ReadOut Plane ID)
+    auto rop = geom->ChannelToROP(fChannelID);
+    fROI_ID = rop.ROP;
+     
+    // Fill tree
+    fTPTree -> Fill();
+  }
+
+  // Fill TA tree
+  for(long unsigned int i=0; i < fTriggerActivity.size(); i++)
+  {
+    fChannel_start_TA = fTriggerActivity[i].channel_start;
+    fChannel_end_TA = fTriggerActivity[i].channel_end;
+    fChannel_peak_TA = fTriggerActivity[i].channel_peak;
+    fTime_start_TA = fTriggerActivity[i].time_start;
+    fTime_end_TA = fTriggerActivity[i].time_end;
+    fTime_peak_TA = fTriggerActivity[i].time_peak;
+    fTime_activity = fTriggerActivity[i].time_activity;
+    fADC_integral_TA = fTriggerActivity[i].adc_integral;
+    fADC_peak_TA = fTriggerActivity[i].adc_peak;
+    fAlgorithm_TA = static_cast<int>(fTriggerActivity[i].algorithm);
+
+    // Fill tree
+    fTATree -> Fill();
+  }
+
+  // Fill TC tree
+  for(long unsigned int i=0; i < fTriggerCandidate.size(); i++)
+  {
+    fTime_start_TC = fTriggerCandidate[i].time_start;
+    fTime_end_TC = fTriggerCandidate[i].time_end;
+    fTime_candidate = fTriggerCandidate[i].time_candidate;
+    version = fTriggerCandidate[i].version;
+    fType_TC = static_cast<int>(fTriggerCandidate[i].type);
+    fAlgorithm_TC = static_cast<int>(fTriggerCandidate[i].algorithm);
+
+    // Fill tree
+    fTCTree -> Fill();
+  }
+}
+
+void duneana::TriggerTPCInfoDisplay::beginJob()
+{
+  // Make our handle to the TFileService
+  art::ServiceHandle<art::TFileService> tfs;
+  // The TTrees
+  fTPTree = tfs->make<TTree>("TPTree", "DAQ trigger primitive maker tree");
+  fTATree = tfs->make<TTree>("TATree", "DAQ trigger activity maker tree");
+  fTCTree = tfs->make<TTree>("TCTree", "DAQ trigger candidate maker tree");
+  
+  ////////////////////////////////////////
+  // fTriggerPrimitive tree information //
+  ////////////////////////////////////////
+  // General event information
+  fTPTree -> Branch( "Event" , &fEventID, "Event/I"  );
+  fTPTree -> Branch( "Run"   , &fRun    , "Run/I"    );
+  fTPTree -> Branch( "SubRun", &fSubRun , "SubRun/I" );
+  // Trigger primitive information
+  fTPTree -> Branch( "ChannelID" , &fChannelID);
+  fTPTree -> Branch( "ROP_ID" , &fROI_ID);
+  fTPTree -> Branch( "Start_time" , &fStart_time);
+  fTPTree -> Branch( "Time_over_threshold" , &fTime_over_threshold);
+  fTPTree -> Branch( "Time_peak" , &fTime_peak);
+  fTPTree -> Branch( "ADC_integral" , &fADC_integral);
+  fTPTree -> Branch( "ADC_peak" , &fADC_peak);
+  fTPTree -> Branch( "DetID" , &fDetID);
+  fTPTree -> Branch( "Type" , &fType);
+  fTPTree -> Branch( "Algorithm" , &fAlgorithm);
+
+  ////////////////////////////////////////
+  // fTriggerActivity tree information //
+  ///////////////////////////////////////
+  // General event information
+  fTATree -> Branch( "Event" , &fEventID, "Event/I"  );
+  fTATree -> Branch( "Run"   , &fRun    , "Run/I"    );
+  fTATree -> Branch( "SubRun", &fSubRun , "SubRun/I" );
+  // Trigger activity information
+  fTATree -> Branch( "Channel_start" , &fChannel_start_TA);
+  fTATree -> Branch( "Channel_end" , &fChannel_end_TA);
+  fTATree -> Branch( "Channel_peak"  , &fChannel_peak_TA);
+  fTATree -> Branch( "Time_start" , &fTime_start_TA);
+  fTATree -> Branch( "Time_end" , &fTime_end_TA);
+  fTATree -> Branch( "Time_peak" , &fTime_peak_TA);
+  fTATree -> Branch( "Time_activity" , &fTime_activity);
+  fTATree -> Branch( "ADC_integral" , &fADC_integral_TA);
+  fTATree -> Branch( "ADC_peak" , &fADC_peak_TA);
+  fTATree -> Branch( "DetID" , &fDetID);
+  fTATree -> Branch( "Type" , &fType);
+  fTATree -> Branch( "Algorithm" , &fAlgorithm_TA);
+
+  ////////////////////////////////////////
+  // fTriggerCandidate tree information //
+  ///////////////////////////////////////
+  // General event information
+  fTCTree -> Branch( "Event" , &fEventID, "Event/I"  );
+  fTCTree -> Branch( "Run"   , &fRun    , "Run/I"    );
+  fTCTree -> Branch( "SubRun", &fSubRun , "SubRun/I" );
+  // Trigger candidate information
+  fTCTree -> Branch( "Time_start" , &fTime_start_TC);
+  fTCTree -> Branch( "Time_end" , &fTime_end_TC);
+  fTCTree -> Branch( "Time_candidate" , &fTime_candidate);
+  fTCTree -> Branch( "Version" , &version);
+  fTCTree -> Branch( "DetID" , &fDetID);
+  fTCTree -> Branch( "Type" , &fType_TC);
+  fTCTree -> Branch( "Algorithm" , &fAlgorithm_TC);
+}
+
+DEFINE_ART_MODULE(duneana::TriggerTPCInfoDisplay)

--- a/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
@@ -1,3 +1,16 @@
+/**
+ * @file TriggerTPCInfoDisplay_module.cc
+ *
+ * @brief This module is an analyzer that displays information about trigger primitives, trigger activities, and trigger candidates.
+ *
+ * It reads trigger primitive, trigger activity, and trigger candidate data from the input event and fills three separate TTree objects with the data.
+ * The module also provides general event information such as run number, subrun number, and event ID.
+ *
+ * The module takes three input tags to specify the collections of trigger primitive, trigger activity, and trigger candidate data.
+ * It also supports an optional verbosity level to control the amount of output printed to the console.
+ *
+ * The filled TTree objects can be used for further analysis or visualization of the trigger data.
+ */
 ////////////////////////////////////////////////////////////////////////
 // Class:       TriggerTPCInfoDisplay
 // Plugin Type: analyzer (Unknown Unknown)

--- a/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
@@ -95,7 +95,7 @@ private:
   timestamp_t fTime_peak;
   uint32_t fADC_integral;
   uint16_t fADC_peak;
-  int fROI_ID;
+  int fROP_ID;
   detid_t fDetID;
   int fType;
   int fAlgorithm;
@@ -194,7 +194,7 @@ void duneana::TriggerTPCInfoDisplay::analyze(art::Event const& e)
     
     // Get ROP ID (ReadOut Plane ID)
     auto rop = geom->ChannelToROP(fChannelID);
-    fROI_ID = rop.ROP;
+    fROP_ID = rop.ROP;
      
     // Fill tree
     fTPTree -> Fill();
@@ -251,7 +251,7 @@ void duneana::TriggerTPCInfoDisplay::beginJob()
   fTPTree -> Branch( "SubRun", &fSubRun , "SubRun/I" );
   // Trigger primitive information
   fTPTree -> Branch( "ChannelID" , &fChannelID);
-  fTPTree -> Branch( "ROP_ID" , &fROI_ID);
+  fTPTree -> Branch( "ROP_ID" , &fROP_ID);
   fTPTree -> Branch( "Start_time" , &fStart_time);
   fTPTree -> Branch( "Time_over_threshold" , &fTime_over_threshold);
   fTPTree -> Branch( "Time_peak" , &fTime_peak);

--- a/example/run_offlineTriggerTPCInfoDisplay.fcl
+++ b/example/run_offlineTriggerTPCInfoDisplay.fcl
@@ -1,0 +1,59 @@
+#include "services_refactored_pdune.fcl"
+#include "protodune_tools_dune.fcl"
+#include "tools_dune.fcl"
+
+process_name: OfflineTriggerTPCInfo
+
+services:
+{
+  TFileService: { fileName: "LArSoftTriggerTPC_hist.root" }
+  TimeTracker:       @local::dune_time_tracker
+  MemoryTracker:     @local::dune_memory_tracker
+  RandomNumberGenerator: {} #ART native random number generator
+  message:              @local::dune_message_services_prod
+  #FileCatalogMetadata:  @local::art_file_catalog_mc
+                        @table::protodunehd_reco_services
+                        @table::protodunehd_services
+  #  ChannelStatusService: @local::pdsp_channel_status
+  IFDH: {}
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:  10        # Number of events to create
+  saveMemoryObjectThreshold: 0
+}
+
+physics:
+{
+
+ analyzers:
+ {
+     offlineTriggerTPCInfoDisplay:
+     {
+         module_type: TriggerTPCInfoDisplay
+         tp_tag: "tpmakerTPC"
+         ta_tag: "tamakerTPC"
+         tc_tag: "tcmakerTPC"
+         verbosity: 1
+     }
+ }
+
+ ana:       [ offlineTriggerTPCInfoDisplay ]
+
+ stream1:   [ out1 ]
+
+ end_paths: [ stream1, ana ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   fileName:    "OfflineTriggerHistogramsTPC_output.root"
+   compressionLevel: 1
+ }
+}
+

--- a/example/run_triggerTPCInfoComparator.fcl
+++ b/example/run_triggerTPCInfoComparator.fcl
@@ -1,0 +1,78 @@
+#include "services_refactored_pdune.fcl"
+#include "protodune_tools_dune.fcl"
+#include "tools_dune.fcl"
+
+process_name: TriggerTPCComparator
+
+services:
+{
+  TFileService: { fileName: "triggerComparator_hist.root" }
+  TimeTracker:       @local::dune_time_tracker
+  MemoryTracker:     @local::dune_memory_tracker
+  RandomNumberGenerator: {} #ART native random number generator
+  message:              @local::dune_message_services_prod
+  #FileCatalogMetadata:  @local::art_file_catalog_mc
+                        @table::protodunehd_reco_services
+                        @table::protodunehd_services
+  #  ChannelStatusService: @local::pdsp_channel_status
+  IFDH: {}
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:  10        # Number of events to create
+  saveMemoryObjectThreshold: 0
+}
+
+physics:
+{
+
+  analyzers:
+ {
+     offlineTriggerTPCInfoDisplay:
+     {
+         module_type: TriggerTPCInfoDisplay
+         tp_tag: "tpmakerTPC"
+         ta_tag: "tamakerTPC"
+         tc_tag: "tcmakerTPC"
+         verbosity: 1
+     }
+
+     onlineTriggerTPCInfoDisplay:
+     {
+         module_type: TriggerTPCInfoDisplay
+         tp_tag: "trigrawdecoder:daq"
+         ta_tag: "trigrawdecoder:daq"
+         tc_tag: "trigrawdecoder:daq"
+         verbosity: 0
+     }
+
+     triggerTPCInfoComparator:
+     {
+         module_type: TriggerTPCInfoComparator
+         tp_tag: "tpmakerTPC"
+         ta_tag: "tamakerTPC"
+         tc_tag: "tcmakerTPC"
+         daq_tag: "trigrawdecoder:daq"
+         verbosity: 0
+     }
+ }
+
+ ana:       [ offlineTriggerTPCInfoDisplay, onlineTriggerTPCInfoDisplay, triggerTPCInfoComparator ]
+
+ stream1:   [ out1 ]
+
+ end_paths: [ stream1, ana ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   fileName:    "TriggerInfoComparatorTPC_output.root"
+   compressionLevel: 1
+ }
+}
+

--- a/example/run_triggerTPCInfoDisplay.fcl
+++ b/example/run_triggerTPCInfoDisplay.fcl
@@ -1,0 +1,68 @@
+#include "services_refactored_pdune.fcl"
+#include "protodune_tools_dune.fcl"
+#include "tools_dune.fcl"
+
+process_name: TriggerTPCInfo
+
+services:
+{
+  TFileService: { fileName: "TriggerTPC_hist.root" }
+  TimeTracker:       @local::dune_time_tracker
+  MemoryTracker:     @local::dune_memory_tracker
+  RandomNumberGenerator: {} #ART native random number generator
+  message:              @local::dune_message_services_prod
+  #FileCatalogMetadata:  @local::art_file_catalog_mc
+                        @table::protodunehd_reco_services
+                        @table::protodunehd_services
+  #  ChannelStatusService: @local::pdsp_channel_status
+  IFDH: {}
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:  10        # Number of events to create
+  saveMemoryObjectThreshold: 0
+}
+
+physics:
+{
+
+  analyzers:
+ {
+     offlineTriggerTPCInfoDisplay:
+     {
+         module_type: TriggerTPCInfoDisplay
+         tp_tag: "tpmakerTPC"
+         ta_tag: "tamakerTPC"
+         tc_tag: "tcmakerTPC"
+         verbosity: 1
+     }
+
+     onlineTriggerTPCInfoDisplay:
+     {
+         module_type: TriggerTPCInfoDisplay
+         tp_tag: "trigrawdecoder:daq"
+         ta_tag: "trigrawdecoder:daq"
+         tc_tag: "trigrawdecoder:daq"
+         verbosity: 1
+     }
+ }
+
+ ana:       [ offlineTriggerTPCInfoDisplay, onlineTriggerTPCInfoDisplay ]
+
+ stream1:   [ out1 ]
+
+ end_paths: [ stream1, ana ]
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   fileName:    "TriggerHistogramsTPC_output.root"
+   compressionLevel: 1
+ }
+}
+


### PR DESCRIPTION
- New analyzer module and fhicls to read trigger information stored in an _Art root file_ and display those within a _histogram root file_. Each tree per trigger information, i.e. TPs, TAs and TCs. 

- Trigger information can be stored either by using the `example/run_offlineTriggerTPCInfoDisplay.fcl` or the `example/run_triggerTPCInfoDisplay.fcl`. The difference lies in whether one wants only offline trigger information (for data emulation purposes) to be displayed or DAQ's as well.

- Typo corrected in file `TPAlgTools/TPAlgTPCTool.hh`.

- The trigger comparator module is also completed. There is a fhicl file that combines both, the display and the comparison features.

- PD: to run this changes I had to modified the file [`dunecore/DuneObj/classes_def.xml`](https://github.com/DUNE/dunecore/pull/111) and included the repository `duneprototypes`. 
The latter due to the map service `duneprototypes_Protodune_hd_ChannelMap_DAPHNEChannelMapService_service` in `trigger_sim_dev/srcs/dunetrigger/dunetrigger/TriggerSim/CMakeLists.txt`.