### PR TITLE
Fix for ST plane threshold data type limit

### DIFF
--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
@@ -21,9 +21,9 @@ namespace duneana {
     explicit TPAlgTPCSimpleThreshold(fhicl::ParameterSet const& ps) :
       verbosity_(ps.get<int>("verbosity",0)),
       accum_limit_(ps.get<int>("accum_limit",10)),
-      threshold_tpg_plane0_(ps.get<int>("threshold_tpg_plane0")),
-      threshold_tpg_plane1_(ps.get<int>("threshold_tpg_plane1")),
-      threshold_tpg_plane2_(ps.get<int>("threshold_tpg_plane2"))
+      threshold_tpg_plane0_(ps.get<int16_t>("threshold_tpg_plane0")),
+      threshold_tpg_plane1_(ps.get<int16_t>("threshold_tpg_plane1")),
+      threshold_tpg_plane2_(ps.get<int16_t>("threshold_tpg_plane2"))
     {}
 
     void initialize_channel_state(dunedaq::trgdataformats::channel_t const& channel,
@@ -162,10 +162,9 @@ namespace duneana {
     //configuration parameters
     const int verbosity_;
     const int accum_limit_;
-    const int threshold_tpg_plane0_;
-    const int threshold_tpg_plane1_;
-    const int threshold_tpg_plane2_;
-
+    const int16_t threshold_tpg_plane0_;
+    const int16_t threshold_tpg_plane1_;
+    const int16_t threshold_tpg_plane2_;
 
     //variables for tracking state / hit-finding
     int16_t threshold_;


### PR DESCRIPTION
This fixes issue discussed in https://github.com/wesketchum/dunetrigger/issues/11

The expected result is now obtained for various TPG thresholds.

- tpg threshold: 15000
```
Begin processing the 1st record. run: 28508 subRun: 1 event: 35 at 05-Aug-2024 06:38:40 CDT
Found 40960 raw::RawDigits
Found 930221 TPs
	 ROP: C:0 S:0 R:0
		 484821 TPs between [18416863793900444961, 18416863793901510913]
	 ROP: C:0 S:0 R:1
		 36522 TPs between [18416863793900732705, 18416863793901246433]
	 ROP: C:0 S:0 R:2
		 16493 TPs between [18416863793900949025, 18416863793901246465]
	 ROP: C:0 S:0 R:3
		 19303 TPs between [18416863793900732705, 18416863793901030400]
	 ROP: C:0 S:1 R:0
		 41810 TPs between [18416863793900704032, 18416863793901215489]
	 ROP: C:0 S:1 R:1
		 30952 TPs between [18416863793900704032, 18416863793901215457]
	 ROP: C:0 S:1 R:2
		 22194 TPs between [18416863793900704032, 18416863793901000449]
	 ROP: C:0 S:1 R:3
		 21591 TPs between [18416863793900919328, 18416863793901215489]
	 ROP: C:0 S:2 R:0
		 39560 TPs between [18416863793900444961, 18416863793901502976]
	 ROP: C:0 S:2 R:1
		 38974 TPs between [18416863793900444961, 18416863793901502976]
	 ROP: C:0 S:2 R:2
		 22329 TPs between [18416863793900444961, 18416863793901502976]
	 ROP: C:0 S:2 R:3
		 23099 TPs between [18416863793900444961, 18416863793901502976]
	 ROP: C:0 S:3 R:0
		 42664 TPs between [18416863793900488993, 18416863793901510913]
	 ROP: C:0 S:3 R:1
		 40234 TPs between [18416863793900488993, 18416863793901510913]
	 ROP: C:0 S:3 R:2
		 26049 TPs between [18416863793901215009, 18416863793901510913]
	 ROP: C:0 S:3 R:3
		 23626 TPs between [18416863793900488993, 18416863793901510913]
Found 9294 TAs
	 9294 TAs between [18416863793900444961, 18416863793901510945]
```

- tpg threshold: 32767  (this is the int16_t limit)
```
Begin processing the 1st record. run: 28508 subRun: 1 event: 35 at 05-Aug-2024 06:39:42 CDT
Found 40960 raw::RawDigits
Found 0 TPs
Found 0 TAs
```
 - tpg threshold: 32768  (above the limit)
```
%MSG-s ArtException:  TriggerPrimitiveMakerTPC:tpmakerTPC@Construction  05-Aug-2024 06:40:12 CDT ModuleConstruction
cet::exception caught in art
---- Configuration BEGIN
  make_tool: 
  ---- Type mismatch BEGIN
    
    Unsuccessful attempt to convert FHiCL parameter 'threshold_tpg_plane0' to type 'short'.
    
    [Specific error:]
    bad numeric conversion: positive overflow
    
  ---- Type mismatch END
  Exception caught while processing plugin spec: TPAlgTPCSimpleThreshold
---- Configuration END
%MSG
```
