### PR TITLE
Name Verbosity Levels

### DIFF
--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
@@ -8,6 +8,7 @@
 #include "larcore/Geometry/Geometry.h"
 
 #include "dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCTool.hh"
+#include "dunetrigger/TriggerSim/Verbosity.hh"
 
 #include <map>
 #include <limits>
@@ -38,7 +39,7 @@ namespace duneana {
         else if(plane==1) threshold_=threshold_tpg_plane1_;
         else if(plane==2) threshold_=threshold_tpg_plane2_;
 
-        if(verbosity_>1) {
+        if(verbosity_ >= Verbosity::kInfo) {
             std::cout << "Channel: " << channel
                       << ", ROP: " << plane
                       << ", Threshold: " << threshold_

--- a/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
@@ -30,6 +30,8 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
+#include "dunetrigger/TriggerSim/Verbosity.hh"
+
 #include <memory>
 #include <algorithm>
 #include <iostream>
@@ -106,7 +108,7 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
   auto tp_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(tp_tag_);
   auto tp_vec = *tp_handle;
 
-  if(verbosity_>0)
+  if(verbosity_ >= Verbosity::kInfo)
     std::cout << "Found " << tp_vec.size() << " TPs" << std::endl;
 
   //need to sort TPs by ROP (APA, CRP...)
@@ -122,7 +124,7 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
   for (auto & tps : tps_per_rop_map) {
     std::sort(tps.second.begin(),tps.second.end(),compareTriggerPrimitive);
 
-    if(verbosity_>0){
+    if(verbosity_ >= Verbosity::kInfo){
       std::cout << "\t ROP: " << tps.first << std::endl;
       std::cout << "\t\t " << tps.second.size() << " TPs between [" 
 		<< tps.second.front()->time_start << ", " << tps.second.back()->time_start

--- a/dunetrigger/TriggerSim/TriggerCandidateMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerCandidateMakerTPC_module.cc
@@ -27,6 +27,8 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
+#include "dunetrigger/TriggerSim/Verbosity.hh"
+
 #include <memory>
 #include <algorithm>
 #include <iostream>
@@ -95,14 +97,14 @@ void duneana::TriggerCandidateMakerTPC::produce(art::Event& e)
   auto ta_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);  
   auto ta_vec = *ta_handle;
 
-  if(verbosity_>0)
+  if(verbosity_ >= Verbosity::kInfo)
     std::cout << "Found " << ta_vec.size() << " TAs" << std::endl;
 
   //we need to sort the tas by time
   //and then, can run the TC algorithm.
   std::sort(ta_vec.begin(),ta_vec.end(),compareTriggerActivity);
 
-  if(verbosity_>0){
+  if(verbosity_ >= Verbosity::kInfo){
     std::cout << "\t " << ta_vec.size() << " TAs between [" 
               << ta_vec.front().time_start << ", " << ta_vec.back().time_end
               << "]" << std::endl;

--- a/dunetrigger/TriggerSim/TriggerPrimitiveMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerPrimitiveMakerTPC_module.cc
@@ -27,6 +27,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "canvas/Persistency/Common/FindOneP.h"
+#include "dunetrigger/TriggerSim/Verbosity.hh"
 
 #include <memory>
 #include <iostream>
@@ -94,7 +95,7 @@ void duneana::TriggerPrimitiveMakerTPC::produce(art::Event& e)
 
   auto rawdigit_vec = *rawdigit_handle;
 
-  if(verbosity_>0)
+  if(verbosity_ >= Verbosity::kInfo)
     std::cout << "Found " << rawdigit_vec.size() << " raw::RawDigits" << std::endl;
 
   uint64_t this_timestamp = default_timestamp_;

--- a/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
@@ -52,6 +52,8 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
+#include "dunetrigger/TriggerSim/Verbosity.hh"
+
 // Additional framework includes
 #include "art_root_io/TFileDirectory.h"
 #include "art_root_io/TFileService.h"
@@ -176,7 +178,7 @@ void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
   // Load the geometry service
   art::ServiceHandle<geo::Geometry> geom;
 
-  if(verbosity_>0)
+  if(verbosity_ >= Verbosity::kInfo)
   {
     std::cout << "Offline summary" << std::endl; 
     std::cout << "Found " << fTriggerPrimitive.size() << " TPs" << std::endl;

--- a/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
@@ -43,6 +43,7 @@
 // Additional framework includes
 #include "art_root_io/TFileDirectory.h"
 #include "art_root_io/TFileService.h"
+#include "dunetrigger/TriggerSim/Verbosity.hh"
 
 // ROOT includes
 #include <TH1I.h>
@@ -184,7 +185,7 @@ void duneana::TriggerTPCInfoDisplay::analyze(art::Event const& e)
   // Load the geometry service
   art::ServiceHandle<geo::Geometry> geom;
 
-  if(verbosity_>0)
+  if(verbosity_ >= Verbosity::kInfo)
   {
     //std::cout << "Found " << rawdigit_vec.size() << " raw::RawDigits" << std::endl;
     std::cout << "Found " << fTriggerPrimitive.size() << " TPs" << std::endl;

--- a/dunetrigger/TriggerSim/Verbosity.hh
+++ b/dunetrigger/TriggerSim/Verbosity.hh
@@ -1,0 +1,16 @@
+#ifndef DUNETRIGGER_TRIGGERSIM_VERSBOSITY_HH
+#define DUNETRIGGER_TRIGGERSIM_VERSBOSITY_HH
+
+namespace duneana{
+    enum Verbosity{
+        // these would all implicitly have these values
+        // but it's best to explicitly define things
+        // for anyone in the future looking
+        kQuiet = 0,
+        kInfo = 1,
+        kDebug = 2,
+        kVerbose = 3
+    };
+}
+
+#endif


### PR DESCRIPTION
For the sake of clarity, as well as keeping the verbosity levels consistent as this package grows I think it would be prudent to store the different verbosity levels in an enum. This clarifies what each verbosity level should be, and gives people an idea of how much information will be printed at each verbosity level.

This PR both creates this enum, and updates the existing source code to use it.