### PR TITLE
ADCSimpleWindow algorithm implemented

### DIFF
--- a/dunetrigger/TriggerSim/TAAlgTools/CMakeLists.txt
+++ b/dunetrigger/TriggerSim/TAAlgTools/CMakeLists.txt
@@ -6,6 +6,14 @@ cet_build_plugin(TAAlgTPCExample art::tool
   cetlib_except
 )
 
+cet_build_plugin(TAAlgTPCADCSimpleWindow art::tool
+  LIBRARIES
+  dunecore::DuneObj
+  fhiclcpp
+  cetlib::cetlib
+  cetlib_except
+)
+
 install_fhicl()
 install_headers()
 install_source()

--- a/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
+++ b/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
@@ -7,6 +7,8 @@
 #include "dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCTool.hh"
 #include "dunetrigger/TriggerSim/TAAlgTools/TPWindow.hh"
 
+#include "dunetrigger/TriggerSim/Verbosity.hh"
+
 namespace duneana {
 
   class TAAlgTPCADCSimpleWindow : public TAAlgTPCTool {
@@ -52,7 +54,13 @@ namespace duneana {
       
       return ta;
     }
-    
+
+    void initialize() override
+    {
+      ta_current_ = TriggerActivity();
+      current_window_ = TPWindow();
+    }
+
     //process TPs one-by-one
     //if adc integral is greater than the specified threshold for a given TP window, construct a TA, and add it to the output TAs vector
     void process_tp(art::Ptr<dunedaq::trgdataformats::TriggerPrimitive> tp,
@@ -66,7 +74,7 @@ namespace duneana {
 	current_window_.reset(input_tp);
 	ta_current_.second.push_back(tp);
 
-	if (verbosity_ > 1) std::cout << " TP start Time: " << input_tp.time_start << ", TP ADC Sum: " << input_tp.adc_integral
+	if (verbosity_ >= Verbosity::kInfo) std::cout << " TP start Time: " << input_tp.time_start << ", TP ADC Sum: " << input_tp.adc_integral
 				      << ", TP TOT: " << input_tp.time_over_threshold << ", TP ADC Peak: " << input_tp.adc_peak
 				      << ", TP Offline Channel ID: " << input_tp.channel << "\n";
 	return;
@@ -86,9 +94,9 @@ namespace duneana {
 	ta_current_.first = construct_ta();
 	
 	tas_out.push_back(ta_current_);
-	ta_current_.second.clear();
-	ta_current_.second.push_back(tp);
-	
+	initialize();
+
+	ta_current_.second.push_back(tp);	
 	current_window_.reset(input_tp);
       }
       // If false, move the window along

--- a/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
+++ b/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
@@ -1,0 +1,110 @@
+#ifndef DUNETRIGGER_TRIGGERSIM_TAALGTPCADCSIMPLEWINDOW_hh
+#define DUNETRIGGER_TRIGGERSIM_TAALGTPCADCSIMPLEWINDOW_hh
+
+#include "fhiclcpp/ParameterSet.h" 
+
+#include "detdataformats/DetID.hpp"
+#include "dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCTool.hh"
+#include "dunetrigger/TriggerSim/TAAlgTools/TPWindow.hh"
+
+namespace duneana {
+
+  class TAAlgTPCADCSimpleWindow : public TAAlgTPCTool {
+
+  public:
+    explicit TAAlgTPCADCSimpleWindow(fhicl::ParameterSet const& ps)
+      : adc_threshold_(ps.get<uint32_t>("adc_threshold", 100000))
+      , window_length_(ps.get<dunedaq::trgdataformats::timestamp_t>("window_length", 10000))
+      , verbosity_(ps.get<int>("verbosity", 0)) //use it for couts
+    {}
+    
+    dunedaq::trgdataformats::TriggerActivityData construct_ta() const
+    {
+      
+      dunedaq::trgdataformats::TriggerActivityData ta;
+      
+      dunedaq::trgdataformats::TriggerPrimitive last_tp = current_window_.inputs.back();
+      
+      ta.time_start = last_tp.time_start;
+      ta.time_end = last_tp.time_start;
+      ta.time_peak = last_tp.time_peak;
+      ta.time_activity = last_tp.time_peak;
+      ta.channel_start = last_tp.channel;
+      ta.channel_end = last_tp.channel;
+      ta.channel_peak = last_tp.channel;
+      ta.adc_integral = current_window_.adc_integral;
+      ta.adc_peak = last_tp.adc_peak;
+      ta.detid = last_tp.detid;
+      ta.type = dunedaq::trgdataformats::TriggerActivityData::Type::kTPC;
+      ta.algorithm = dunedaq::trgdataformats::TriggerActivityData::Algorithm::kADCSimpleWindow;
+      
+      for (const auto& tp : current_window_.inputs) {
+	ta.time_start = std::min(ta.time_start, tp.time_start);
+	ta.time_end = std::max(ta.time_end, tp.time_start);
+	ta.channel_start = std::min(ta.channel_start, tp.channel);
+	ta.channel_end = std::max(ta.channel_end, tp.channel);
+	if (tp.adc_peak > ta.adc_peak) {
+	  ta.time_peak = tp.time_peak;
+	  ta.adc_peak = tp.adc_peak;
+	  ta.channel_peak = tp.channel;
+	}
+      }
+      
+      return ta;
+    }
+    
+    //process TPs one-by-one
+    //if adc integral is greater than the specified threshold for a given TP window, construct a TA, and add it to the output TAs vector
+    void process_tp(art::Ptr<dunedaq::trgdataformats::TriggerPrimitive> tp,
+		    std::vector<TriggerActivity> & tas_out)
+    {
+      
+      ta_current_.second.push_back(tp);
+
+      dunedaq::trgdataformats::TriggerPrimitive input_tp = *tp;
+
+      // For the first TP, reset the window object.
+      if (current_window_.is_empty()) {
+	if (verbosity_ > 1) std::cout << " TP Start Time: " << input_tp.time_start << ", TP ADC Sum: " << input_tp.adc_integral
+				      << ", TP TOT: " << input_tp.time_over_threshold << ", TP ADC Peak: " << input_tp.adc_peak
+				      << ", TP Offline Channel ID: " << input_tp.channel << "\n";
+	current_window_.reset(input_tp);
+	return;
+      } 
+
+      // If the difference between the current TP's start time and the window's start time
+      // is less than the specified window length, add the TP to the window
+      if ((input_tp.time_start - current_window_.time_start) < window_length_) {
+	current_window_.add(input_tp);
+      }
+      // If the addition of the current TP to the window makes it longer
+      // than the specified window length, don't add it but check whether the adc integral in
+      // the existing window is above the specified threshold. If true, make a TA and start 
+      // a fresh window with the current TP.
+      else if (current_window_.adc_integral > adc_threshold_) {
+	ta_current_.first = construct_ta();
+        tas_out.push_back(ta_current_);
+	ta_current_.second.clear();
+	current_window_.reset(input_tp);
+      }
+      // If false, move the window along
+      else{
+	current_window_.move(input_tp, window_length_);
+      }
+
+      return;      
+    }
+    
+    
+  private:
+    uint32_t adc_threshold_;
+    dunedaq::trgdataformats::timestamp_t window_length_;
+    const int verbosity_;
+    
+    TPWindow current_window_;
+    TriggerActivity ta_current_;
+  };
+  
+}
+
+#endif

--- a/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
+++ b/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
@@ -106,7 +106,7 @@ namespace duneana {
 	    }
 	  }
 	}
-	if (current_window_.inputs.size() != ta_current_.second.size())
+	if (verbosity_ > 1 && current_window_.inputs.size() != ta_current_.second.size())
 	  std::cout<<"current_window_.inputs.size() "<<current_window_.inputs.size()<<" ta_current_.second.size() "<<ta_current_.second.size()<<"\n";
       }
 

--- a/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
+++ b/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh
@@ -83,13 +83,31 @@ namespace duneana {
       // a fresh window with the current TP.
       else if (current_window_.adc_integral > adc_threshold_) {
 	ta_current_.first = construct_ta();
-        tas_out.push_back(ta_current_);
+
+	tas_out.push_back(ta_current_);
 	ta_current_.second.clear();
+	ta_current_.second.push_back(tp);
+
 	current_window_.reset(input_tp);
       }
       // If false, move the window along
       else{
 	current_window_.move(input_tp, window_length_);
+
+	art::PtrVector<dunedaq::trgdataformats::TriggerPrimitive> tmp_tp_vec = ta_current_.second;
+	ta_current_.second.clear();
+	for (const auto& tp_window : current_window_.inputs) {
+	  for (const auto& tp_tmp : tmp_tp_vec) {
+	    if (tp_window.time_start == (*tp_tmp).time_start && 
+		tp_window.adc_integral == (*tp_tmp).adc_integral && 
+		tp_window.time_over_threshold == (*tp_tmp).time_over_threshold) {
+	      ta_current_.second.push_back(tp_tmp);
+	      break;
+	    }
+	  }
+	}
+	if (current_window_.inputs.size() != ta_current_.second.size())
+	  std::cout<<"current_window_.inputs.size() "<<current_window_.inputs.size()<<" ta_current_.second.size() "<<ta_current_.second.size()<<"\n";
       }
 
       return;      

--- a/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow_tool.cc
+++ b/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow_tool.cc
@@ -1,0 +1,5 @@
+#include "art/Utilities/ToolMacros.h" 
+
+#include "dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCADCSimpleWindow.hh"
+
+DEFINE_ART_CLASS_TOOL(duneana::TAAlgTPCADCSimpleWindow)

--- a/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCTool.hh
+++ b/dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCTool.hh
@@ -20,6 +20,7 @@ namespace duneana {
     virtual ~TAAlgTPCTool() noexcept = default; 
 
     virtual void initialize() {};
+    dunedaq::trgdataformats::TriggerActivityData construct_ta() const;
     virtual void process_tp(art::Ptr<dunedaq::trgdataformats::TriggerPrimitive> tp,
 			                std::vector<TriggerActivity> & tas_out) = 0;
   };

--- a/dunetrigger/TriggerSim/TAAlgTools/TPWindow.hh
+++ b/dunetrigger/TriggerSim/TAAlgTools/TPWindow.hh
@@ -1,0 +1,119 @@
+#ifndef DUNETRIGGER_TRIGGERSIM_TPWINDOW_HH_
+#define DUNETRIGGER_TRIGGERSIM_TPWINDOW_HH_
+
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "detdataformats/trigger/Types.hpp"
+
+#include <ostream>
+#include <unordered_map>
+#include <vector>
+
+namespace duneana {
+  
+  class TPWindow
+  {
+  public:
+    
+    bool
+    is_empty() const
+    {
+      return inputs.empty();
+    }
+    
+    void
+    add(dunedaq::trgdataformats::TriggerPrimitive const& input_tp)
+    {
+      // Add the input TP's contribution to the total ADC, increase hit
+      // channel's hit count and add it to the TP list.
+      adc_integral += input_tp.adc_integral;
+      channel_states[input_tp.channel]++;
+      inputs.push_back(input_tp);
+    }
+    
+    void
+    clear()
+    {
+      inputs.clear();
+      channel_states.clear();
+      time_start = 0;
+      adc_integral = 0;
+    }
+    
+    uint16_t
+    n_channels_hit()
+    {
+      return channel_states.size();
+    }
+    
+    void
+    move(dunedaq::trgdataformats::TriggerPrimitive const& input_tp, dunedaq::trgdataformats::timestamp_t const& window_length)
+    {
+      // Find all of the TPs in the window that need to be removed
+      // if the input_tp is to be added and the size of the window
+      // is to be conserved.
+      // Substract those TPs' contribution from the total window ADC and remove their
+      // contributions to the hit counts.
+      uint32_t n_tps_to_erase = 0;
+      for (auto tp : inputs) {
+	if (!(input_tp.time_start - tp.time_start < window_length)) {
+	  n_tps_to_erase++;
+	  adc_integral -= tp.adc_integral;
+	  channel_states[tp.channel]--;
+	  // If a TP being removed from the window results in a channel no longer having
+	  // any hits, remove from the states map so map.size() can be used for number
+	  // channels hit.
+	  if (channel_states[tp.channel] == 0)
+	    channel_states.erase(tp.channel);
+	} else
+	  break;
+      }
+      // Erase the TPs from the window.
+      inputs.erase(inputs.begin(), inputs.begin() + n_tps_to_erase);
+      // Make the window start time the start time of what is now the first TP.
+      
+      if (inputs.size() != 0) {
+	time_start = inputs.front().time_start;
+	add(input_tp);
+      } else {
+	reset(input_tp);
+      }
+    }
+    
+    void
+    reset(dunedaq::trgdataformats::TriggerPrimitive const& input_tp)
+    {
+      
+      // Empty the channel and TP lists.
+      channel_states.clear();
+      inputs.clear();
+      // Set the start time of the window to be the start time of theinput_tp.
+      time_start = input_tp.time_start;
+      // Start the total ADC integral.
+      adc_integral = input_tp.adc_integral;
+      // Start hit count for the hit channel.
+      channel_states[input_tp.channel]++;
+      // Add the input TP to the TP list.
+      inputs.push_back(input_tp);
+      // std::cout << "Number of channels hit: " << n_channels_hit() << std::endl;
+    }
+    
+    friend std::ostream& operator<<(std::ostream& os, const TPWindow& window)
+    {
+      if (window.is_empty()) {
+	os << "Window is empty!\n";
+      } else {
+	os << "Window start: " << window.time_start << ", end: " << window.inputs.back().time_start;
+	os << ". Total of: " << window.adc_integral << " ADC counts with " << window.inputs.size() << " TPs.\n";
+	os << window.channel_states.size() << " independent channels have hits.\n";
+      }
+      return os;
+    }
+    
+    dunedaq::trgdataformats::timestamp_t time_start;
+    uint32_t adc_integral;
+    std::unordered_map<dunedaq::trgdataformats::channel_t, uint16_t> channel_states;
+    std::vector<dunedaq::trgdataformats::TriggerPrimitive> inputs;
+  };
+} // namespace duneana
+
+#endif // DUNETRIGGER_TRIGGERSIM_TPWINDOW_HH_

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
@@ -100,8 +100,6 @@ namespace duneana {
         //for this channel, reinitialize the channel state variables
         initialize_channel_state(channel, adcs);
 
-	// std::cout<<" channel "<<channel<<" adcs.size() "<<adcs.size()<<" pedestal_ "<<pedestal_<<" start_time "<<start_time<<"\n";
-
         for(size_t i_t=0; i_t<adcs.size(); ++i_t){
 
 	  //if threshold < 0, the plane is not used to produce TPs

--- a/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
@@ -117,14 +117,26 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
     auto rop = geom->ChannelToROP(tp_vec[i_tp].channel);
 
     //TPs in the colleciton plane arrive in two sets, eg for APA1, they have rops (0, 0, 2) and (0, 0, 3)
-    //merging the two TP sets (fixme: it is only working for data when only collection plane was active, eg, PD-2 run028508)
-    readout::ROPID c0_r0_t2 = {0, 0, 2}, c0_r1_t2 = {0, 1, 2}, c0_r2_t2 = {0, 2, 2}, c0_r3_t2 = {0, 3, 2}; 
+    //merging the two TP sets (fixme: it is only working for 4 detector module setup for the moment)
+    readout::ROPID c0_r0_t0 = {0, 0, 0}, c0_r1_t0 = {0, 1, 0}, c0_r2_t0 = {0, 2, 0}, c0_r3_t0 = {0, 3, 0}; 
+    readout::ROPID c0_r0_t1 = {0, 0, 1}, c0_r1_t1 = {0, 1, 1}, c0_r2_t1 = {0, 2, 1}, c0_r3_t1 = {0, 3, 1};
+    readout::ROPID c0_r0_t2 = {0, 0, 2}, c0_r1_t2 = {0, 1, 2}, c0_r2_t2 = {0, 2, 2}, c0_r3_t2 = {0, 3, 2};
     readout::ROPID c0_r0_t3 = {0, 0, 3}, c0_r1_t3 = {0, 1, 3}, c0_r2_t3 = {0, 2, 3}, c0_r3_t3 = {0, 3, 3};
     int det_module = 0;
-    if (rop == c0_r0_t2 || rop == c0_r0_t3 ) det_module = 0;
-    else if (rop == c0_r1_t2 || rop == c0_r1_t3) det_module = 1;
-    else if (rop == c0_r2_t2 || rop == c0_r2_t3) det_module = 2;
-    else if (rop == c0_r3_t2 || rop == c0_r3_t3) det_module = 3;
+    if (c0_r0_t0) det_module = 0;
+    if (c0_r1_t0) det_module = 1;
+    if (c0_r2_t0) det_module = 2;
+    if (c0_r3_t0) det_module = 3;
+
+    if (c0_r0_t1) det_module = 10;
+    if (c0_r1_t1) det_module = 11;
+    if (c0_r2_t1) det_module = 12;
+    if (c0_r3_t1) det_module = 13;
+
+    if (rop == c0_r0_t2 || rop == c0_r0_t3) det_module = 20;
+    if (rop == c0_r1_t2 || rop == c0_r1_t3) det_module = 21;
+    if (rop == c0_r2_t2 || rop == c0_r2_t3) det_module = 22;
+    if (rop == c0_r3_t2 || rop == c0_r3_t3) det_module = 23;
     tps_per_rop_map[det_module].push_back( art::Ptr<dunedaq::trgdataformats::TriggerPrimitive>(tp_handle,i_tp) );
   }
 

--- a/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
@@ -144,13 +144,8 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
   for (auto & tps : tps_per_rop_map) {
     std::sort(tps.second.begin(),tps.second.end(),compareTriggerPrimitive);
 
-<<<<<<< HEAD
     if(verbosity_  >= Verbosity::kInfo){
       std::cout << "\t Tmp plane number: " << tps.first << std::endl;
-=======
-    if(verbosity_ >= Verbosity::kInfo){
-      std::cout << "\t Detector module number: " << tps.first << std::endl;
->>>>>>> 5e10977f94de871324e062cb3810bf72dd993817
       std::cout << "\t\t " << tps.second.size() << " TPs between [" 
 		<< tps.second.front()->time_start << ", " << tps.second.back()->time_start
 		<< "]" << std::endl;

--- a/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
@@ -9,6 +9,7 @@
 
 
 #include "dunetrigger/TriggerSim/TAAlgTools/TAAlgTPCTool.hh"
+#include "dunetrigger/TriggerSim/Verbosity.hh"
 
 #include "detdataformats/trigger/TriggerActivityData.hpp"
 #include "detdataformats/trigger/TriggerPrimitive.hpp"
@@ -59,6 +60,8 @@ private:
   // Declare member data here.
   art::InputTag tp_tag_;
   std::unique_ptr<TAAlgTPCTool> taalg_;
+  int n_modules_;
+  bool mergecollwires_;
   int verbosity_;
 
   static bool compareTriggerPrimitive(art::Ptr<dunedaq::trgdataformats::TriggerPrimitive> tp1,
@@ -70,6 +73,8 @@ duneana::TriggerActivityMakerTPC::TriggerActivityMakerTPC(fhicl::ParameterSet co
   : EDProducer{p}  // ,
   , tp_tag_(p.get<art::InputTag>("tp_tag"))
   , taalg_{art::make_tool<TAAlgTPCTool>(p.get<fhicl::ParameterSet>("taalg"))}
+  , n_modules_(p.get<int>("nmodules"))
+  , mergecollwires_(p.get<bool>("mergecollwires", false))
   , verbosity_(p.get<int>("verbosity",0))
 {
   // Call appropriate produces<>() functions here.
@@ -106,7 +111,7 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
   auto tp_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(tp_tag_);
   auto tp_vec = *tp_handle;
 
-  if(verbosity_>0)
+  if(verbosity_ >= Verbosity::kInfo)
     std::cout << "Found " << tp_vec.size() << " TPs" << std::endl;
 
   //need to sort TPs per plane per detector module (APA, CRP...)
@@ -114,30 +119,23 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
   std::map< int, art::PtrVector<dunedaq::trgdataformats::TriggerPrimitive> > tps_per_rop_map;
   for( size_t i_tp=0; i_tp < tp_vec.size(); ++i_tp) {
 
+    //TPs in the colleciton plane arrive in two sets (due to collection wires facing in two different directions)
+    //merge them if mergecollwires_ is true
     auto rop = geom->ChannelToROP(tp_vec[i_tp].channel);
 
-    //TPs in the colleciton plane arrive in two sets, eg for APA1, they have rops (0, 0, 2) and (0, 0, 3)
-    //merging the two TP sets (fixme: it is only working for 4 detector module setup for the moment)
-    readout::ROPID c0_r0_t0 = {0, 0, 0}, c0_r1_t0 = {0, 1, 0}, c0_r2_t0 = {0, 2, 0}, c0_r3_t0 = {0, 3, 0}; 
-    readout::ROPID c0_r0_t1 = {0, 0, 1}, c0_r1_t1 = {0, 1, 1}, c0_r2_t1 = {0, 2, 1}, c0_r3_t1 = {0, 3, 1};
-    readout::ROPID c0_r0_t2 = {0, 0, 2}, c0_r1_t2 = {0, 1, 2}, c0_r2_t2 = {0, 2, 2}, c0_r3_t2 = {0, 3, 2};
-    readout::ROPID c0_r0_t3 = {0, 0, 3}, c0_r1_t3 = {0, 1, 3}, c0_r2_t3 = {0, 2, 3}, c0_r3_t3 = {0, 3, 3};
-    int det_module = 0;
-    if (c0_r0_t0) det_module = 0;
-    if (c0_r1_t0) det_module = 1;
-    if (c0_r2_t0) det_module = 2;
-    if (c0_r3_t0) det_module = 3;
-
-    if (c0_r0_t1) det_module = 10;
-    if (c0_r1_t1) det_module = 11;
-    if (c0_r2_t1) det_module = 12;
-    if (c0_r3_t1) det_module = 13;
-
-    if (rop == c0_r0_t2 || rop == c0_r0_t3) det_module = 20;
-    if (rop == c0_r1_t2 || rop == c0_r1_t3) det_module = 21;
-    if (rop == c0_r2_t2 || rop == c0_r2_t3) det_module = 22;
-    if (rop == c0_r3_t2 || rop == c0_r3_t3) det_module = 23;
-    tps_per_rop_map[det_module].push_back( art::Ptr<dunedaq::trgdataformats::TriggerPrimitive>(tp_handle,i_tp) );
+    int tmp_plane = 0;
+    for (short unsigned int i = 0; i < n_modules_; i ++) {
+      for (short unsigned int j = 0; j < 4; j ++) {
+	
+	readout::ROPID tmp_rop = {0, i, j};
+	if (j < 2 && rop == tmp_rop) tmp_plane = j*n_modules_ + i;
+	else if (j >= 2 && rop == tmp_rop) {
+	  if (mergecollwires_) tmp_plane = 2*n_modules_ + i;
+	  else tmp_plane = j*n_modules_ + i;
+	}
+      }
+    }
+    tps_per_rop_map[tmp_plane].push_back( art::Ptr<dunedaq::trgdataformats::TriggerPrimitive>(tp_handle,i_tp) );
   }
 
   //now, per map, we need to sort the tps by time
@@ -145,8 +143,8 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
   for (auto & tps : tps_per_rop_map) {
     std::sort(tps.second.begin(),tps.second.end(),compareTriggerPrimitive);
 
-    if(verbosity_>0){
-      std::cout << "\t Detector module number: " << tps.first << std::endl;
+    if(verbosity_  >= Verbosity::kInfo){
+      std::cout << "\t Tmp plane number: " << tps.first << std::endl;
       std::cout << "\t\t " << tps.second.size() << " TPs between [" 
 		<< tps.second.front()->time_start << ", " << tps.second.back()->time_start
 		<< "]" << std::endl;

--- a/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerActivityMakerTPC_module.cc
@@ -142,7 +142,7 @@ void duneana::TriggerActivityMakerTPC::produce(art::Event& e)
 
     //create an output vector and initialize our taalg
     std::vector< TAAlgTPCTool::TriggerActivity> tas_out;
-    // taalg_->initialize();
+    taalg_->initialize();
 
     //loop through the TPs and process
     for( auto const& tp : tps.second)

--- a/dunetrigger/TriggerSim/TriggerPrimitiveMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerPrimitiveMakerTPC_module.cc
@@ -98,7 +98,7 @@ void duneana::TriggerPrimitiveMakerTPC::produce(art::Event& e)
     std::cout << "Found " << rawdigit_vec.size() << " raw::RawDigits" << std::endl;
 
   uint64_t this_timestamp = default_timestamp_;
-  for(size_t i_digit=0; i_digit<rawdigit_vec.size(); ++i_digit) {
+  for(size_t i_digit=0; i_digit<rawdigit_vec.size(); ++i_digit) {// rawdigit_vec.size()
     auto const& digit = rawdigit_vec[i_digit];
 
     if(rd_assn_is_valid) {

--- a/dunetrigger/TriggerSim/TriggerPrimitiveMakerTPC_module.cc
+++ b/dunetrigger/TriggerSim/TriggerPrimitiveMakerTPC_module.cc
@@ -98,7 +98,7 @@ void duneana::TriggerPrimitiveMakerTPC::produce(art::Event& e)
     std::cout << "Found " << rawdigit_vec.size() << " raw::RawDigits" << std::endl;
 
   uint64_t this_timestamp = default_timestamp_;
-  for(size_t i_digit=0; i_digit<rawdigit_vec.size(); ++i_digit) {// rawdigit_vec.size()
+  for(size_t i_digit=0; i_digit<rawdigit_vec.size(); ++i_digit) {
     auto const& digit = rawdigit_vec[i_digit];
 
     if(rd_assn_is_valid) {

--- a/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
@@ -31,7 +31,6 @@
 // Generated at Mon Apr 29 11:24:28 2024 by Hamza Amar Es-sghir using cetskelgen
 // from  version .
 ////////////////////////////////////////////////////////////////////////
-
 #include "detdataformats/trigger/TriggerCandidateData.hpp"
 #include "detdataformats/trigger/TriggerActivityData.hpp"
 #include "detdataformats/trigger/TriggerPrimitive.hpp"
@@ -132,14 +131,14 @@ duneana::TriggerTPCInfoComparator::TriggerTPCInfoComparator(fhicl::ParameterSet 
   , verbosity_(p.get<int>("verbosity",0))
 {
   // Consumes offline trigger information
-  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive>>(tp_tag_);
-  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData>>(ta_tag_);
-  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData>>(tc_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(tp_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData> >(tc_tag_);
 
   // Consumes DAQ trigger information
-  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive>>(daq_tag);
-  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData>>(daq_tag);
-  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData>>(daq_tag);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive> >(daq_tag);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData> >(daq_tag);
+  consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData> >(daq_tag);
 }
 
 void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
@@ -199,29 +198,28 @@ void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
     for (long unsigned int j = 0; j < fTriggerPrimitiveDAQ.size(); j++) {
       // Compare TPs and set comparison result
       if (fTriggerPrimitive[i].channel == fTriggerPrimitiveDAQ[j].channel &&
-        fTriggerPrimitive[i].time_start == fTriggerPrimitiveDAQ[j].time_start &&
-        fTriggerPrimitive[i].time_over_threshold == fTriggerPrimitiveDAQ[j].time_over_threshold &&
-        fTriggerPrimitive[i].time_peak == fTriggerPrimitiveDAQ[j].time_peak &&
-        fTriggerPrimitive[i].adc_integral == fTriggerPrimitiveDAQ[j].adc_integral &&
-        fTriggerPrimitive[i].adc_peak == fTriggerPrimitiveDAQ[j].adc_peak &&
-        fTriggerPrimitive[i].detid == fTriggerPrimitiveDAQ[j].detid &&
-        fTriggerPrimitive[i].type == fTriggerPrimitiveDAQ[j].type &&
-        fTriggerPrimitive[i].algorithm == fTriggerPrimitiveDAQ[j].algorithm) {
-      foundMatch = true;
-      break; // Break the loop if a match is found
+	  fTriggerPrimitive[i].time_start == fTriggerPrimitiveDAQ[j].time_start && //== 172096 &&
+	  fTriggerPrimitive[i].time_over_threshold == fTriggerPrimitiveDAQ[j].time_over_threshold &&
+	  fTriggerPrimitive[i].time_peak == fTriggerPrimitiveDAQ[j].time_peak && // == 172096 &&
+	  fTriggerPrimitive[i].adc_integral == fTriggerPrimitiveDAQ[j].adc_integral &&
+	  fTriggerPrimitive[i].adc_peak == fTriggerPrimitiveDAQ[j].adc_peak &&
+	  fTriggerPrimitive[i].detid == fTriggerPrimitiveDAQ[j].detid &&
+	  fTriggerPrimitive[i].type == fTriggerPrimitiveDAQ[j].type &&
+	  fTriggerPrimitive[i].algorithm == fTriggerPrimitiveDAQ[j].algorithm) {
+	foundMatch = true;
+	break; // Break the loop if a match is found
       }
     }
-
     fTPComparison[i] = foundMatch; // Set comparison result
-  } 
+  }
 
   // Compare offline and online TAs
   fTASizeOffline = fTriggerActivity.size();
   fTASizeOnline = fTriggerActivityDAQ.size();
   long unsigned int minTASize = std::min(fTASizeOffline, fTASizeOnline);
-  fTAComparison.resize(minTASize);
+  fTAComparison.resize(minTPSize);
   for (long unsigned int i = 0; i < minTASize; i++) {
-    bool foundMatch = false; // to check if a match is found
+    bool foundMatch = false; //  to check if a match is found
     for(long unsigned int j = 0; j < fTriggerActivityDAQ.size(); j++) {
       // Compare TAs and set comparison result
       if (fTriggerActivity[i].channel_start == fTriggerActivityDAQ[j].channel_start &&
@@ -247,9 +245,9 @@ void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
   fTCSizeOffline = fTriggerCandidate.size();
   fTCSizeOnline = fTriggerCandidateDAQ.size();
   long unsigned int minTCSize = std::min(fTCSizeOffline, fTCSizeOnline);
-  fTCComparison.resize(minTCSize);
+  fTCComparison.resize(minTPSize);
   for (long unsigned int i = 0; i < minTCSize; i++) {
-    bool foundMatch = false; // to check if a match is found
+    bool foundMatch = false; //  to check if a match is found
     for (long unsigned int j = 0; j < fTriggerCandidateDAQ.size(); j++) {
       // Compare TCs and set comparison result
       if (fTriggerCandidate[i].time_start == fTriggerCandidateDAQ[j].time_start &&
@@ -283,13 +281,25 @@ void duneana::TriggerTPCInfoComparator::beginJob()
   fTCComparisonTree = tfs->make<TTree>("TCComparisonTree", "Offline vs Online TC Comparison");
 
   // Set branch addresses for comparison TTrees
+  fTPComparisonTree->Branch("Event" , &fEventID, "Event/I");
+  fTPComparisonTree->Branch("Run"   , &fRun    , "Run/I");
+  fTPComparisonTree->Branch("SubRun", &fSubRun , "SubRun/I");
+
   fTPComparisonTree->Branch("SizeOffline", &fTPSizeOffline, "SizeOffline/I");
   fTPComparisonTree->Branch("SizeOnline", &fTPSizeOnline, "SizeOnline/I");
   fTPComparisonTree->Branch("Comparison", &fTPComparison);
 
+  fTAComparisonTree->Branch("Event" , &fEventID, "Event/I");
+  fTAComparisonTree->Branch("Run"   , &fRun    , "Run/I");
+  fTAComparisonTree->Branch("SubRun", &fSubRun , "SubRun/I");
+
   fTAComparisonTree->Branch("SizeOffline", &fTASizeOffline, "SizeOffline/I");
   fTAComparisonTree->Branch("SizeOnline", &fTASizeOnline, "SizeOnline/I");
   fTAComparisonTree->Branch("Comparison", &fTAComparison);
+
+  fTCComparisonTree->Branch("Event" , &fEventID, "Event/I");
+  fTCComparisonTree->Branch("Run"   , &fRun    , "Run/I");
+  fTCComparisonTree->Branch("SubRun", &fSubRun , "SubRun/I");
 
   fTCComparisonTree->Branch("SizeOffline", &fTCSizeOffline, "SizeOffline/I");
   fTCComparisonTree->Branch("SizeOnline", &fTCSizeOnline, "SizeOnline/I");

--- a/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoComparator_module.cc
@@ -198,9 +198,9 @@ void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
     for (long unsigned int j = 0; j < fTriggerPrimitiveDAQ.size(); j++) {
       // Compare TPs and set comparison result
       if (fTriggerPrimitive[i].channel == fTriggerPrimitiveDAQ[j].channel &&
-	  fTriggerPrimitive[i].time_start == fTriggerPrimitiveDAQ[j].time_start && //== 172096 &&
+	  fTriggerPrimitive[i].time_start == fTriggerPrimitiveDAQ[j].time_start &&
 	  fTriggerPrimitive[i].time_over_threshold == fTriggerPrimitiveDAQ[j].time_over_threshold &&
-	  fTriggerPrimitive[i].time_peak == fTriggerPrimitiveDAQ[j].time_peak && // == 172096 &&
+	  fTriggerPrimitive[i].time_peak == fTriggerPrimitiveDAQ[j].time_peak &&
 	  fTriggerPrimitive[i].adc_integral == fTriggerPrimitiveDAQ[j].adc_integral &&
 	  fTriggerPrimitive[i].adc_peak == fTriggerPrimitiveDAQ[j].adc_peak &&
 	  fTriggerPrimitive[i].detid == fTriggerPrimitiveDAQ[j].detid &&
@@ -217,7 +217,7 @@ void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
   fTASizeOffline = fTriggerActivity.size();
   fTASizeOnline = fTriggerActivityDAQ.size();
   long unsigned int minTASize = std::min(fTASizeOffline, fTASizeOnline);
-  fTAComparison.resize(minTPSize);
+  fTAComparison.resize(minTASize);
   for (long unsigned int i = 0; i < minTASize; i++) {
     bool foundMatch = false; //  to check if a match is found
     for(long unsigned int j = 0; j < fTriggerActivityDAQ.size(); j++) {
@@ -245,7 +245,7 @@ void duneana::TriggerTPCInfoComparator::analyze(art::Event const& e)
   fTCSizeOffline = fTriggerCandidate.size();
   fTCSizeOnline = fTriggerCandidateDAQ.size();
   long unsigned int minTCSize = std::min(fTCSizeOffline, fTCSizeOnline);
-  fTCComparison.resize(minTPSize);
+  fTCComparison.resize(minTCSize);
   for (long unsigned int i = 0; i < minTCSize; i++) {
     bool foundMatch = false; //  to check if a match is found
     for (long unsigned int j = 0; j < fTriggerCandidateDAQ.size(); j++) {

--- a/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
@@ -37,6 +37,7 @@
 #include "art/Framework/Principal/SubRun.h"
 #include "art/Utilities/make_tool.h"
 #include "canvas/Utilities/InputTag.h"
+#include "canvas/Persistency/Common/Assns.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
@@ -86,6 +87,7 @@ private:
 
   // Create output Tree
   TTree *fTPTree;
+  TTree *fTPfromTPTATree;
   TTree *fTATree;
   TTree *fTCTree;
 
@@ -97,7 +99,7 @@ private:
   ////////////////////////
   // fTPTree variables //
   ///////////////////////
-  using timestamp_t = int64_t;
+  using timestamp_t = uint64_t;
   using channel_t = uint32_t;
   using version_t = uint16_t;
   using detid_t = uint16_t;
@@ -112,6 +114,17 @@ private:
   detid_t fDetID;
   int fType;
   int fAlgorithm;
+
+  ///////////////////////////
+  // fTPfromTPTATree variables //
+  ///////////////////////////
+  int fTAnumber;
+  channel_t fChannelID_TPinTA;
+  timestamp_t fStart_time_TPinTA;
+  timestamp_t fTime_over_threshold_TPinTA;
+  timestamp_t fTime_peak_TPinTA;
+  uint32_t fADC_integral_TPinTA;
+  uint16_t fADC_peak_TPinTA;
 
   ////////////////////////
   // fTATree variables //
@@ -159,6 +172,8 @@ duneana::TriggerTPCInfoDisplay::TriggerTPCInfoDisplay(fhicl::ParameterSet const&
 {
   consumes<std::vector<dunedaq::trgdataformats::TriggerPrimitive>>(tp_tag_);
   consumes<std::vector<dunedaq::trgdataformats::TriggerActivityData>>(ta_tag_);
+  consumes<art::Assns<dunedaq::trgdataformats::TriggerActivityData, dunedaq::trgdataformats::TriggerPrimitive> >(ta_tag_);
+  consumes<art::Assns<dunedaq::trgdataformats::TriggerPrimitive, dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);
   consumes<std::vector<dunedaq::trgdataformats::TriggerCandidateData>>(tc_tag_);
 }
 
@@ -176,6 +191,14 @@ void duneana::TriggerTPCInfoDisplay::analyze(art::Event const& e)
   // Take TAs from event
   auto ta_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);
   fTriggerActivity = *ta_handle;
+
+  // Take TPs from TP-TA association from event
+  auto tpfromtpta_handle = e.getValidHandle< art::Assns<dunedaq::trgdataformats::TriggerPrimitive, dunedaq::trgdataformats::TriggerActivityData> >(ta_tag_);
+  auto fTPfromTPTA = *tpfromtpta_handle;
+
+  // Take TAs from TP-TA association from event
+  auto tafromtpta_handle = e.getValidHandle< art::Assns<dunedaq::trgdataformats::TriggerActivityData, dunedaq::trgdataformats::TriggerPrimitive> >(ta_tag_);
+  auto fTAfromTPTA = *tafromtpta_handle;
 
   // Take TCs from event
   auto tc_handle = e.getValidHandle< std::vector<dunedaq::trgdataformats::TriggerCandidateData> >(tc_tag_);
@@ -213,6 +236,31 @@ void duneana::TriggerTPCInfoDisplay::analyze(art::Event const& e)
     fTPTree -> Fill();
   }
 
+  // Fill TPinTA tree
+  uint32_t ta_adc_int = 0;
+  timestamp_t ta_start_time = 0;
+  int ta_count = 0;
+  for(long unsigned int i=0; i < fTPfromTPTA.size(); i++)
+  {
+    if (fTAfromTPTA[i].first->adc_integral != ta_adc_int && fTAfromTPTA[i].first->time_start != ta_start_time) {
+      ta_adc_int = fTAfromTPTA[i].first->adc_integral;
+      ta_start_time = fTAfromTPTA[i].first->time_start;
+      ta_count++;
+      std::cout<<"For TA number "<<ta_count<<", the adc_integral and start_time are "<<ta_adc_int<<" and "<<ta_start_time<<"\n";
+    }
+
+    fTAnumber = ta_count;
+    fChannelID_TPinTA = fTPfromTPTA[i].first->channel;
+    fStart_time_TPinTA = fTPfromTPTA[i].first->time_start;
+    fTime_over_threshold_TPinTA = fTPfromTPTA[i].first->time_over_threshold;
+    fTime_peak_TPinTA = fTPfromTPTA[i].first->time_peak;
+    fADC_integral_TPinTA = fTPfromTPTA[i].first->adc_integral;
+    fADC_peak_TPinTA = fTPfromTPTA[i].first->adc_peak;
+    
+    // Fill tree
+    fTPfromTPTATree -> Fill();
+  }
+  
   // Fill TA tree
   for(long unsigned int i=0; i < fTriggerActivity.size(); i++)
   {
@@ -252,6 +300,7 @@ void duneana::TriggerTPCInfoDisplay::beginJob()
   art::ServiceHandle<art::TFileService> tfs;
   // The TTrees
   fTPTree = tfs->make<TTree>("TPTree", "DAQ trigger primitive maker tree");
+  fTPfromTPTATree = tfs->make<TTree>("TPinTATree", "DAQ trigger primitive in trigger activity tree");
   fTATree = tfs->make<TTree>("TATree", "DAQ trigger activity maker tree");
   fTCTree = tfs->make<TTree>("TCTree", "DAQ trigger candidate maker tree");
   
@@ -273,6 +322,20 @@ void duneana::TriggerTPCInfoDisplay::beginJob()
   fTPTree -> Branch( "DetID" , &fDetID);
   fTPTree -> Branch( "Type" , &fType);
   fTPTree -> Branch( "Algorithm" , &fAlgorithm);
+
+  //////////////////////////////
+  // fTPfromTPTA tree information //
+  //////////////////////////////
+  fTPfromTPTATree -> Branch( "Event" , &fEventID, "Event/I"  );
+  fTPfromTPTATree -> Branch( "Run"   , &fRun    , "Run/I"    );
+  fTPfromTPTATree -> Branch( "SubRun", &fSubRun , "SubRun/I" );
+  fTPfromTPTATree -> Branch( "TAnumber", &fTAnumber , "TAnumber/I" );
+  fTPfromTPTATree -> Branch( "ChannelID" , &fChannelID_TPinTA);
+  fTPfromTPTATree -> Branch( "Start_time" , &fStart_time_TPinTA);
+  fTPfromTPTATree -> Branch( "Time_over_threshold" , &fTime_over_threshold_TPinTA);
+  fTPfromTPTATree -> Branch( "Time_peak" , &fTime_peak_TPinTA);
+  fTPfromTPTATree -> Branch( "ADC_integral" , &fADC_integral_TPinTA);
+  fTPfromTPTATree -> Branch( "ADC_peak" , &fADC_peak_TPinTA);
 
   ////////////////////////////////////////
   // fTriggerActivity tree information //

--- a/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
+++ b/dunetrigger/TriggerSim/TriggerTPCInfoDisplay_module.cc
@@ -238,18 +238,19 @@ void duneana::TriggerTPCInfoDisplay::analyze(art::Event const& e)
   }
 
   // Fill TPinTA tree
+  int ta_channel_start = 0;
   uint32_t ta_adc_int = 0;
-  timestamp_t ta_start_time = 0;
   int ta_count = 0;
   for(long unsigned int i=0; i < fTPfromTPTA.size(); i++)
   {
-    if (fTAfromTPTA[i].first->adc_integral != ta_adc_int && fTAfromTPTA[i].first->time_start != ta_start_time) {
+    if (fTAfromTPTA[i].first->channel_start != ta_channel_start || fTAfromTPTA[i].first->adc_integral != ta_adc_int) {
+      ta_channel_start = fTAfromTPTA[i].first->channel_start;
       ta_adc_int = fTAfromTPTA[i].first->adc_integral;
-      ta_start_time = fTAfromTPTA[i].first->time_start;
       ta_count++;
-      std::cout<<"For TA number "<<ta_count<<", the adc_integral and start_time are "<<ta_adc_int<<" and "<<ta_start_time<<"\n";
+      if(verbosity_ >= Verbosity::kInfo)
+	std::cout<<"For TA number "<<ta_count<<", the channel_start, start_time and adc_integral are  "<<ta_channel_start<<", "<<fTAfromTPTA[i].first->time_start<<" and "<<ta_adc_int<<"\n";
     }
-
+    
     fTAnumber = ta_count;
     fChannelID_TPinTA = fTPfromTPTA[i].first->channel;
     fStart_time_TPinTA = fTPfromTPTA[i].first->time_start;

--- a/example/run_pdhd_tpc_decoder.fcl
+++ b/example/run_pdhd_tpc_decoder.fcl
@@ -1,14 +1,7 @@
-<<<<<<< HEAD
 #include "HDF5RawInput3.fcl"
 #include "PDHDTPCReader.fcl"
 #include "PDHDTriggerReader3.fcl"
 #include "PDHDDataInterfaceWIBEth3.fcl"
-=======
-#include "HDF5RawInput2.fcl"
-#include "PDHDTPCReader.fcl"
-#include "PDHDTriggerReader.fcl"
-#include "PDHDDataInterfaceWIBEth.fcl"
->>>>>>> 5e10977f94de871324e062cb3810bf72dd993817
 
 services:
 {
@@ -29,17 +22,10 @@ physics:
   producers:
   {
     tpcrawdecoder: @local::PDHDTPCReaderDefaults
-<<<<<<< HEAD
     trigrawdecoder: @local::PDHDTriggerReader3Defaults
   }
 
   produce: [ trigrawdecoder, tpcrawdecoder ]
-=======
-    trigrawdecoder: @local::PDHDTriggerReaderDefaults
-  }
-
-  produce: [ trigrawdecoder, tpcrawdecoder ] 
->>>>>>> 5e10977f94de871324e062cb3810bf72dd993817
   output: [ out1 ]
   trigger_paths : [ produce ]
   end_paths: [ output ]
@@ -55,19 +41,11 @@ outputs:
   }
 }
 
-<<<<<<< HEAD
 source: @local::hdf5rawinput3
 services.HDF5RawFile3Service:  {}
 
 process_name: runpdhdtpcdecodermodule
 
 physics.producers.tpcrawdecoder.DecoderToolParams: @local::PDHDDataInterfaceWIBEth3Defaults
-=======
-source: @local::hdf5rawinput2
-
-process_name: runpdhdtpcdecodermodule
-
-physics.producers.tpcrawdecoder.DecoderToolParams: @local::PDHDDataInterfaceWIBEthDefaults
->>>>>>> 5e10977f94de871324e062cb3810bf72dd993817
 services.PD2HDChannelMapService.FileName: "PD2HDChannelMap_WIBEth_electronics_v1.txt"
 

--- a/example/run_pdhd_tpc_decoder.fcl
+++ b/example/run_pdhd_tpc_decoder.fcl
@@ -1,0 +1,51 @@
+#include "HDF5RawInput3.fcl"
+#include "PDHDTPCReader.fcl"
+#include "PDHDTriggerReader3.fcl"
+#include "PDHDDataInterfaceWIBEth3.fcl"
+
+services:
+{
+  TimeTracker:  {}
+  TFileService: 
+  {
+    fileName: "pdhdtpcdecodermoduleTFile.root"
+  } 
+  HDF5RawFile2Service:  {}
+  PD2HDChannelMapService: 
+   {
+     FileName: "PD2HDChannelMap_v4.txt"
+   }
+}
+
+physics:
+{
+  producers:
+  {
+    tpcrawdecoder: @local::PDHDTPCReaderDefaults
+    trigrawdecoder: @local::PDHDTriggerReader3Defaults
+  }
+
+  produce: [ trigrawdecoder, tpcrawdecoder ]
+  output: [ out1 ]
+  trigger_paths : [ produce ]
+  end_paths: [ output ]
+} 	     
+
+outputs:
+{
+  out1:
+  {
+    compressionLevel: 1
+    module_type: RootOutput
+    fileName: "%ifb_decode.root"
+  }
+}
+
+source: @local::hdf5rawinput3
+services.HDF5RawFile3Service:  {}
+
+process_name: runpdhdtpcdecodermodule
+
+physics.producers.tpcrawdecoder.DecoderToolParams: @local::PDHDDataInterfaceWIBEth3Defaults
+services.PD2HDChannelMapService.FileName: "PD2HDChannelMap_WIBEth_electronics_v1.txt"
+

--- a/example/run_tpalg_taalg_tcalg.fcl
+++ b/example/run_tpalg_taalg_tcalg.fcl
@@ -34,8 +34,11 @@ physics:
          module_type: TriggerPrimitiveMakerTPC
          rawdigit_tag: "tpcrawdecoder:daq"
          tpalg: {
-             tool_type: TPAlgTPCExample
-             verbosity: 1
+             tool_type: TPAlgTPCSimpleThreshold
+             threshold_tpg_plane0: 50
+             threshold_tpg_plane1: 50
+             threshold_tpg_plane2: 50
+             verbosity: 0
          }
          verbosity: 1
      }
@@ -45,9 +48,10 @@ physics:
          module_type: TriggerActivityMakerTPC
          tp_tag: "tpmakerTPC"
          taalg: {
-             tool_type: TAAlgTPCExample
-             multiplicity: 100
-             verbosity: 1
+	     tool_type: TAAlgTPCADCSimpleWindow 
+	     adc_threshold: 100000
+	     window_length: 10000
+	     verbosity: 0
          }
          verbosity: 1
      }

--- a/example/run_tpalg_taalg_tcalg.fcl
+++ b/example/run_tpalg_taalg_tcalg.fcl
@@ -38,7 +38,7 @@ physics:
              threshold_tpg_plane0: -1
              threshold_tpg_plane1: -1
              threshold_tpg_plane2: 60
-             verbosity: 1
+             verbosity: 0
          }
          verbosity: 1
      }
@@ -51,10 +51,10 @@ physics:
 	     tool_type: TAAlgTPCADCSimpleWindow 
 	     adc_threshold: 20000000
 	     window_length: 60000
-	     verbosity: 1
+	     verbosity: 2
          }
          nmodules: 4
-         mergecollwires: false
+         mergecollwires: true
          verbosity: 1
      }
 

--- a/example/run_tpalg_taalg_tcalg.fcl
+++ b/example/run_tpalg_taalg_tcalg.fcl
@@ -35,10 +35,10 @@ physics:
          rawdigit_tag: "tpcrawdecoder:daq"
          tpalg: {
              tool_type: TPAlgTPCSimpleThreshold
-             threshold_tpg_plane0: 50
-             threshold_tpg_plane1: 50
-             threshold_tpg_plane2: 50
-             verbosity: 0
+             threshold_tpg_plane0: -1
+             threshold_tpg_plane1: -1
+             threshold_tpg_plane2: 60
+             verbosity: 1
          }
          verbosity: 1
      }
@@ -49,9 +49,9 @@ physics:
          tp_tag: "tpmakerTPC"
          taalg: {
 	     tool_type: TAAlgTPCADCSimpleWindow 
-	     adc_threshold: 100000
-	     window_length: 10000
-	     verbosity: 0
+	     adc_threshold: 20000000
+	     window_length: 60000
+	     verbosity: 1
          }
          verbosity: 1
      }

--- a/example/run_tpalg_taalg_tcalg.fcl
+++ b/example/run_tpalg_taalg_tcalg.fcl
@@ -53,6 +53,8 @@ physics:
 	     window_length: 60000
 	     verbosity: 1
          }
+         nmodules: 4
+         mergecollwires: false
          verbosity: 1
      }
 


### PR DESCRIPTION
- ADCSimpleWindow trigger activity maker algorithm is implemented!
- Offline and online performances agree: number of TAs constructed per event are similar (mostly the same) and properties of TPs making TAs are similar (mostly the same)

**example 1: run028508; event 1; TA 1: same number of TPs making online and offline TAs**

**online TA (left; 3276 TPs) and offline TA (right; 3276 TPs)**

<img width="301" alt="Screenshot 2024-09-06 at 19 48 30" src="https://github.com/user-attachments/assets/980bb7d8-e701-43d5-a0b2-97e8a1da4aa6"><img width="301" alt="Screenshot 2024-09-06 at 19 49 51" src="https://github.com/user-attachments/assets/781a0827-c948-4615-bb27-de885cde13e5">

**with exactly same properties, eg, TP channel ID and TP adc integral (red: online; black: offline; completely overlapped!)**
<img width="300" alt="Screenshot 2024-09-06 at 20 02 55" src="https://github.com/user-attachments/assets/2491f4de-93b3-4f8e-a7e6-57ac10ebc9fa"><img width="302" alt="Screenshot 2024-09-06 at 20 11 27" src="https://github.com/user-attachments/assets/5d4e5d5b-bc21-4797-ba77-e1b90351f408">

**example 2: run028508; event 3; TA 1: similar number of TPs making online and offline TAs**

**online TA (left; 2706 TPs) and offline TA (right; 2730 TPs)**

<img width="303" alt="Screenshot 2024-09-06 at 20 25 36" src="https://github.com/user-attachments/assets/ecee2416-a5f8-4a5d-9ce6-2b5c833530d6"><img width="303" alt="Screenshot 2024-09-06 at 20 27 06" src="https://github.com/user-attachments/assets/8d22a523-07bd-45ea-9c3c-5eb8903f2faa">

**with similar properties, eg, TP channel ID and TP adc integral (red: online; black: offline)**
<img width="301" alt="Screenshot 2024-09-07 at 12 27 42" src="https://github.com/user-attachments/assets/dc503138-5640-4aee-9221-ec4396bd4d62"><img width="302" alt="Screenshot 2024-09-06 at 20 16 08" src="https://github.com/user-attachments/assets/63e65422-b00a-4f94-9af8-f1635e464e3a">

